### PR TITLE
fix filepath can freeze subs search when contains chars as '%2F' in encoded url

### DIFF
--- a/plugin/subtitles.py
+++ b/plugin/subtitles.py
@@ -24,6 +24,7 @@ import re
 import sys
 from threading import Thread
 import traceback
+import urllib
 from twisted.internet.defer import Deferred
 from twisted.web import client
 
@@ -4026,7 +4027,7 @@ class SubsSearch(Screen):
         self.seeker = seeker
         self.searchExpression = searchTitles[0]
         self.searchTitles = searchTitles
-        self.filepath = filepath
+        self.filepath = urllib.unquote(filepath)
         self.isLocalFilepath = filepath and os.path.isfile(filepath) or False
         self.searchTitle = searchSettings.title
         self.searchType = searchSettings.type


### PR DESCRIPTION
etc. filePath=https://test.sk/download/lvxwSjQs7AXAC6VT%2F1jZTLZmekfXgF05v%2FC2eiilvTFOKgUrm%2BqdXFCHL82%2B8YFGDx5ZemfgXAQJxj2OKt4mOTxQDm%2FGCQnaTHXHOEAD3CKqhwsSmmdY/sample.mkv